### PR TITLE
Update API URL after Xero Entrust certificates depreciation

### DIFF
--- a/lib/xeroizer/partner_application.rb
+++ b/lib/xeroizer/partner_application.rb
@@ -19,8 +19,8 @@ module Xeroizer
       # @return [PartnerApplication] instance of PrivateApplication
       def initialize(consumer_key, consumer_secret, path_to_private_key, ssl_client_cert, ssl_client_key, options = {})
         default_options = {
-          :xero_url         => 'https://api-partner.network.xero.com/api.xro/2.0',
-          :site             => 'https://api-partner.network.xero.com',
+          :xero_url         => 'https://api.xero.com/api.xro/2.0',
+          :site             => 'https://api.xero.com',
           :authorize_url    => 'https://api.xero.com/oauth/Authorize',
           :signature_method => 'RSA-SHA1'
         }


### PR DESCRIPTION
[As stated here](https://developer.xero.com/documentation/auth-and-limits/entrust-certificate-deprecation), it is required to change Xero API endpoints after Xero deprecated Entrust certificates.