### PR TITLE
Don't use xeroizer ca-certs anymore

### DIFF
--- a/lib/xeroizer/oauth.rb
+++ b/lib/xeroizer/oauth.rb
@@ -35,8 +35,7 @@ module Xeroizer
         :site               => "https://api.xero.com",
         :request_token_path => "/oauth/RequestToken",
         :access_token_path  => "/oauth/AccessToken",
-        :authorize_path     => "/oauth/Authorize",
-        :ca_file            => File.expand_path(File.join(File.dirname(__FILE__), 'ca-certificates.crt'))
+        :authorize_path     => "/oauth/Authorize"
       }.freeze
     end
     


### PR DESCRIPTION
Xero has updated his certificates policy and is now relying on AWS Root Certificates instead of Entrust ones. So we don't need to specify Entrust ca-certs anymore.